### PR TITLE
Publish docker image to be used in tempo examples

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
-/examples
+/examples/**/*.yml
+/examples/**/*.yaml
 *.md
 Dockerfile

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,6 +1,6 @@
 name: Lint and Test
 
-on: [push]
+on: pull_request
 
 jobs:
   lint-and-test:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set-up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version: ^1.19
           cache: true
 
       - name: Lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set-up Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: ^1.19
+          cache: true
+
+      - name: Test
+        run: make test
+
+      - name: Docker set up buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker login
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ghcr.io/grafana/xk6-client-tracing:latest,ghcr.io/grafana/xk6-client-tracing:${{ github.event.release.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,7 @@ RUN make build
 FROM alpine:latest
 
 COPY --from=xk6-client-tracing-build /opt/xk6-client-tracing/k6-tracing /k6-tracing
+COPY ./examples/template/template.js /example-script.js
+
 ENTRYPOINT [ "/k6-tracing" ]
+CMD ["run", "/example-script.js"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS xk6-client-tracing-build
+FROM golang:1.19-alpine AS xk6-client-tracing-build
 
 RUN apk add --no-cache \
     build-base \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 BINARY     ?= k6-tracing
-IMAGE      ?= grafana/xk6-client-tracing
+IMAGE      ?= ghcr.io/grafana/xk6-client-tracing
 IMAGE_TAG  ?= latest
 
 GO_MODULE      := $(shell head -n1 go.mod | cut -d' ' -f2)

--- a/examples/param/docker-compose.yml
+++ b/examples/param/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ./param.js:/param.js:ro
     depends_on:
       - otel-collector
+    restart: always
 
   otel-collector:
     image: otel/opentelemetry-collector:latest

--- a/examples/param/param.js
+++ b/examples/param/param.js
@@ -4,11 +4,12 @@ import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export let options = {
     vus: 1,
-    duration: "5m",
+    duration: "20m",
 };
 
+const endpoint = __ENV.ENDPOINT || "otel-collector:4317"
 const client = new tracing.Client({
-    endpoint: "otel-collector:4317",
+    endpoint,
     exporter: tracing.EXPORTER_OTLP,
     insecure: true,
 });

--- a/examples/template/docker-compose.yml
+++ b/examples/template/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - ./template.js:/template.js:ro
     depends_on:
       - otel-collector
+    restart: always
 
   otel-collector:
     image: otel/opentelemetry-collector:latest

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -26,9 +26,26 @@ const traceTemplates = [
             {service: "shop-backend", name: "authenticate", duration: {min: 50, max: 100}},
             {service: "auth-service", name: "authenticate"},
             {service: "shop-backend", name: "fetch-articles", parentIdx: 0},
-            {service: "article-service", name: "get-articles"},
+            {service: "article-service", name: "list-articles"},
             {service: "article-service", name: "select-articles", attributeSemantics: tracing.SEMANTICS_DB},
             {service: "postgres", name: "query-articles", attributeSemantics: tracing.SEMANTICS_DB, randomAttributes: {count: 5}},
+        ]
+    },
+    {
+        defaults: {
+            attributeSemantics: tracing.SEMANTICS_HTTP,
+        },
+        spans: [
+            {service: "shop-backend", name: "article-to-cart", duration: {min: 400, max: 1200}},
+            {service: "shop-backend", name: "authenticate", duration: {min: 70, max: 200}},
+            {service: "auth-service", name: "authenticate"},
+            {service: "shop-backend", name: "get-article", parentIdx: 0},
+            {service: "article-service", name: "get-article"},
+            {service: "article-service", name: "select-articles", attributeSemantics: tracing.SEMANTICS_DB},
+            {service: "postgres", name: "query-articles", attributeSemantics: tracing.SEMANTICS_DB, randomAttributes: {count: 2}},
+            {service: "shop-backend", name: "place-articles", parentIdx: 0},
+            {service: "cart-service", name: "place-articles", attributes: {"article.count": 1, "http.status_code": 201}},
+            {service: "cart-service", name: "persist-cart"}
         ]
     },
     {

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -3,11 +3,12 @@ import tracing from 'k6/x/tracing';
 
 export const options = {
     vus: 1,
-    duration: "5m",
+    duration: "20m",
 };
 
+const endpoint = __ENV.ENDPOINT || "otel-collector:4317"
 const client = new tracing.Client({
-    endpoint: "otel-collector:4317",
+    endpoint,
     exporter: tracing.EXPORTER_OTLP,
     insecure: true,
 });

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -1,5 +1,6 @@
 import {sleep} from 'k6';
 import tracing from 'k6/x/tracing';
+import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export const options = {
     vus: 1,
@@ -60,13 +61,11 @@ const traceTemplates = [
 ]
 
 export default function () {
-    traceTemplates.forEach(function (tmpl) {
-        let gen = new tracing.TemplatedGenerator(tmpl)
-        let traces = gen.traces()
-        client.push(traces)
-    });
+    const templateIndex = randomIntBetween(0, traceTemplates.length-1)
+    const gen = new tracing.TemplatedGenerator(traceTemplates[templateIndex])
+    client.push(gen.traces())
 
-    sleep(5);
+    sleep(randomIntBetween(1, 5));
 }
 
 export function teardown() {


### PR DESCRIPTION
### What this PR does:

This PR contains changes required to publish a `xk6-client-tracing` docker image that runs k6 to generate traces and send them to a OTLP or Jaeger endpoints:

* Make endpoints in examples configurable
* Add example script to docker image
* GitHub action to build and publish the image when a new release is created

The published docker image can also be used as a replacement for the synthetic-load-generator in Tempos' docker-compose examples. To run an example with xk6-client-tracing replace the load generator service in the respective docker-compose.yaml with the following snippet:
```yaml
  k6-client-tracing:
    image: ghcr.io/grafana/xk6-client-tracing:latest
    environment:
      - ENDPOINT=tempo:4317
    restart: always
    depends_on:
      - tempo
```
