### PR TITLE
Fix net peer attributes values in client spans

### DIFF
--- a/pkg/tracegen/templated.go
+++ b/pkg/tracegen/templated.go
@@ -245,9 +245,9 @@ func (g *TemplatedGenerator) generateNetworkAttributes(tmpl *internalSpanTemplat
 
 		if parent != nil && parent.Kind() == ptrace.SpanKindClient {
 			ip, _ := span.Attributes().Get("net.sock.host.addr")
-			putIfNotExists(parent.Attributes(), "net.sock.peer.addr", ip)
+			putIfNotExists(parent.Attributes(), "net.sock.peer.addr", ip.Str())
 			name, _ := span.Attributes().Get("net.host.name")
-			putIfNotExists(parent.Attributes(), "net.peer.name", name)
+			putIfNotExists(parent.Attributes(), "net.peer.name", name.Str())
 		}
 	}
 }


### PR DESCRIPTION
### What this PR does:

Fix a bug where the attributs `net.sock.peer.addr` and `net.peer.name` had invalid values `<Invalid value type pcommon.Value>`.