### PR TITLE
Add ghcr.io/... to image tag in docker-compose.yml examples

### DIFF
--- a/examples/param/docker-compose.yml
+++ b/examples/param/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   k6-tracing:
-    image: grafana/xk6-client-tracing:latest
+    image: ghcr.io/grafana/xk6-client-tracing:latest
     command:
       - run
       - /param.js

--- a/examples/template/docker-compose.yml
+++ b/examples/template/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   k6-tracing:
-    image: grafana/xk6-client-tracing:latest
+    image: ghcr.io/grafana/xk6-client-tracing:latest
     command:
       - run
       - /template.js


### PR DESCRIPTION
Running `make docker` tags the Docker images with `ghcr.io/...` prefix. (https://github.com/grafana/xk6-client-tracing/blob/main/Makefile#L2)