### PR TITLE
Configure for multi-tenant clusters

### DIFF
--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -12,6 +12,9 @@ const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,
     insecure: true,
+    headers: {
+        "X-Scope-Orgid": "test"
+    }
 });
 
 const traceDefaults = {

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -8,7 +8,7 @@ export const options = {
 };
 
 const endpoint = __ENV.ENDPOINT || "otel-collector:4317"
-const orgid = __ENV.TEMPO_X_SCOPE_ORGID || "test"
+const orgid = __ENV.TEMPO_X_SCOPE_ORGID || "k6-test"
 const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -8,12 +8,13 @@ export const options = {
 };
 
 const endpoint = __ENV.ENDPOINT || "otel-collector:4317"
+const orgid = __ENV.TEMPO_X_SCOPE_ORGID || "test"
 const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,
     insecure: true,
     headers: {
-        "X-Scope-Orgid": "test"
+        "X-Scope-Orgid": orgid
     }
 });
 


### PR DESCRIPTION
pass X-Scope-Orgid headers to make it work with multi-tenant clusters.

without this change, it fails to push data to tempo clusters that have `multitenancy_enabled: true` need `x-scope-orgid` headers, and tempo clusters with `multitenancy_enabled: false` will ignore `x-scope-orgid` headers.

so set `x-scope-orgid` headers to make it work `multitenancy_enabled: true` clusters.

