### PR TITLE
Add links and events to tracing payload

### DIFF
--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -22,8 +22,8 @@ const traceDefaults = {
     attributeSemantics: tracing.SEMANTICS_HTTP,
     attributes: {"one": "three"},
     randomAttributes: {count: 2, cardinality: 5},
-    eventDefaults: {generateExceptionOnError: true, count: 1.0, randomAttributes: {count: 2, cardinality: 3}},
-    linkDefaults: {linkToPreviousSpanIndex: true, count: 1.0, randomAttributes: {count: 2, cardinality: 3}},
+    randomEvents: {generateExceptionOnError: true, rate: 1.0, randomAttributes: {count: 2, cardinality: 3}},
+    randomLinks: {rate: 1.0, randomAttributes: {count: 2, cardinality: 3}},
 }
 
 const traceTemplates = [
@@ -71,8 +71,8 @@ const traceTemplates = [
             {service: "shop-backend", attributes: {"http.status_code": 403}},
             {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
             {service: "auth-service", name: "authenticate", attributes: {"http.status_code": 403}},
-            {service: "cart-service", name: "checkout", randomEvents: {exceptionCount: 1, count: 2, randomAttributes: {count: 5, cardinality: 2}}},
-            {service: "billing-service", name: "payment", randomLinks: {linkToPreviousSpanIndex: true, count: 2, randomAttributes: {count: 3, cardinality: 2}}}
+            {service: "cart-service", name: "checkout", randomEvents: {exceptionRate: 1, rate: 2, randomAttributes: {count: 5, cardinality: 2}}},
+            {service: "billing-service", name: "payment", randomLinks: {rate: 2, randomAttributes: {count: 3, cardinality: 2}}}
         ]
     },
 ]

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -21,7 +21,9 @@ const client = new tracing.Client({
 const traceDefaults = {
     attributeSemantics: tracing.SEMANTICS_HTTP,
     attributes: {"one": "three"},
-    randomAttributes: {count: 2, cardinality: 5}
+    randomAttributes: {count: 2, cardinality: 5},
+    eventDefaults: {generateExceptionOnError: true, count: 1.0, randomAttributes: {count: 2, cardinality: 3}},
+    linkDefaults: {linkToPreviousSpanIndex: true, count: 1.0, randomAttributes: {count: 2, cardinality: 3}},
 }
 
 const traceTemplates = [
@@ -61,6 +63,16 @@ const traceTemplates = [
             {service: "shop-backend", attributes: {"http.status_code": 403}},
             {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
             {service: "auth-service", name: "authenticate", attributes: {"http.status_code": 403}},
+        ]
+    },
+    {
+        defaults: traceDefaults,
+        spans: [
+            {service: "shop-backend", attributes: {"http.status_code": 403}},
+            {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
+            {service: "auth-service", name: "authenticate", attributes: {"http.status_code": 403}},
+            {service: "test-random", name: "events", randomEvents: {exceptionCount: 1, count: 2, randomAttributes: {count: 5, cardinality: 2}}},
+            {service: "test-random", name: "links", randomLinks: {linkToPreviousSpanIndex: true, count: 2, randomAttributes: {count: 3, cardinality: 2}}}
         ]
     },
 ]

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -71,8 +71,8 @@ const traceTemplates = [
             {service: "shop-backend", attributes: {"http.status_code": 403}},
             {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
             {service: "auth-service", name: "authenticate", attributes: {"http.status_code": 403}},
-            {service: "test-random", name: "events", randomEvents: {exceptionCount: 1, count: 2, randomAttributes: {count: 5, cardinality: 2}}},
-            {service: "test-random", name: "links", randomLinks: {linkToPreviousSpanIndex: true, count: 2, randomAttributes: {count: 3, cardinality: 2}}}
+            {service: "cart-service", name: "checkout", randomEvents: {exceptionCount: 1, count: 2, randomAttributes: {count: 5, cardinality: 2}}},
+            {service: "billing-service", name: "payment", randomLinks: {linkToPreviousSpanIndex: true, count: 2, randomAttributes: {count: 3, cardinality: 2}}}
         ]
     },
 ]

--- a/pkg/tracegen/parameterized.go
+++ b/pkg/tracegen/parameterized.go
@@ -114,7 +114,7 @@ func (g *ParameterizedGenerator) generateSpan(t *TraceParams, dest ptrace.Span) 
 	event := span.Events().AppendEmpty()
 	event.SetName(random.K6String(12))
 	event.SetTimestamp(pcommon.NewTimestampFromTime(startTime))
-	event.Attributes().PutStr("event attribute"+random.K6String(5), random.K6String(12))
+	event.Attributes().PutStr(random.K6String(5), random.K6String(12))
 
 	link := span.Links().AppendEmpty()
 	link.SetTraceID(traceID)

--- a/pkg/tracegen/parameterized.go
+++ b/pkg/tracegen/parameterized.go
@@ -114,7 +114,12 @@ func (g *ParameterizedGenerator) generateSpan(t *TraceParams, dest ptrace.Span) 
 	event := span.Events().AppendEmpty()
 	event.SetName(random.K6String(12))
 	event.SetTimestamp(pcommon.NewTimestampFromTime(startTime))
-	event.Attributes().PutStr(random.K6String(12), random.K6String(12))
+	event.Attributes().PutStr("event attribute"+random.K6String(5), random.K6String(12))
+
+	link := span.Links().AppendEmpty()
+	link.SetTraceID(traceID)
+	link.SetSpanID(random.SpanID())
+	link.Attributes().PutStr(random.K6String(12), random.K6String(12))
 
 	status := span.Status()
 	status.SetCode(1)

--- a/pkg/tracegen/templated_test.go
+++ b/pkg/tracegen/templated_test.go
@@ -58,8 +58,8 @@ func TestTemplatedGenerator_EventsLinks(t *testing.T) {
 		Defaults: SpanDefaults{
 			Attributes:       map[string]interface{}{"fixed.attr": "some-value"},
 			RandomAttributes: &AttributeParams{Count: 3},
-			LinkDefaults:     LinkParams{Rate: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
-			EventDefaults:    EventParams{GenerateExceptionOnError: true, Rate: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
+			RandomLinks:      LinkParams{Rate: 1, RandomAttributes: &AttributeParams{Count: 3}},
+			RandomEvents:     EventParams{GenerateExceptionOnError: true, Rate: 1, RandomAttributes: &AttributeParams{Count: 3}},
 		},
 		Spans: []SpanTemplate{
 			// do not change order of the first one

--- a/pkg/tracegen/templated_test.go
+++ b/pkg/tracegen/templated_test.go
@@ -81,10 +81,10 @@ func TestTemplatedGenerator_EventsLinks(t *testing.T) {
 			spans := collectSpansFromTrace(traces)
 
 			assert.Len(t, spans, len(template.Spans))
-			for i, span := range spans {
+			for _, span := range spans {
 				events := span.Events()
 				links := span.Links()
-				checkEventsLinksLength := func(spanIndex, expectedTemplate, expectedRandom int, spanName string) {
+				checkEventsLinksLength := func(expectedTemplate, expectedRandom int, spanName string) {
 					expected := expectedTemplate + expectedRandom
 					// because default rate is 0.5
 					assert.GreaterOrEqual(t, events.Len(), expected, "test name: %s events", spanName)
@@ -103,7 +103,7 @@ func TestTemplatedGenerator_EventsLinks(t *testing.T) {
 
 				switch span.Name() {
 				case "only_default":
-					checkEventsLinksLength(i, 0, 0, span.Name())
+					checkEventsLinksLength(0, 0, span.Name())
 					if events.Len() > 0 {
 						// check default event with 3 random attributes
 						event := events.At(0)
@@ -119,13 +119,13 @@ func TestTemplatedGenerator_EventsLinks(t *testing.T) {
 						assert.NotEqual(t, span.ParentSpanID(), link.SpanID())
 					}
 				case "default_and_template":
-					checkEventsLinksLength(i, 1, 0, span.Name())
+					checkEventsLinksLength(1, 0, span.Name())
 					checkLinks()
 				case "default_and_random":
-					checkEventsLinksLength(i, 0, 2, span.Name())
+					checkEventsLinksLength(0, 2, span.Name())
 					checkLinks()
 				case "default_template_random":
-					checkEventsLinksLength(i, 1, 2, span.Name())
+					checkEventsLinksLength(1, 2, span.Name())
 					checkLinks()
 				case "default_generate_on_error":
 					// there should be at least one event

--- a/pkg/tracegen/templated_test.go
+++ b/pkg/tracegen/templated_test.go
@@ -58,8 +58,8 @@ func TestTemplatedGenerator_EventsLinks(t *testing.T) {
 		Defaults: SpanDefaults{
 			Attributes:       map[string]interface{}{"fixed.attr": "some-value"},
 			RandomAttributes: &AttributeParams{Count: 3},
-			RandomLinks:      LinkParams{Rate: 1, RandomAttributes: &AttributeParams{Count: 3}},
-			RandomEvents:     EventParams{GenerateExceptionOnError: true, Rate: 1, RandomAttributes: &AttributeParams{Count: 3}},
+			RandomLinks:      LinkParams{Rate: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
+			RandomEvents:     EventParams{GenerateExceptionOnError: true, Rate: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
 		},
 		Spans: []SpanTemplate{
 			// do not change order of the first one

--- a/pkg/tracegen/templated_test.go
+++ b/pkg/tracegen/templated_test.go
@@ -52,6 +52,99 @@ func TestTemplatedGenerator_Traces(t *testing.T) {
 	}
 }
 
+func TestTemplatedGenerator_EventsLinks(t *testing.T) {
+	attributeSemantics := []OTelSemantics{SemanticsHTTP}
+	template := TraceTemplate{
+		Defaults: SpanDefaults{
+			Attributes:       map[string]interface{}{"fixed.attr": "some-value"},
+			RandomAttributes: &AttributeParams{Count: 3},
+			LinkDefaults:     LinkDefaults{LinkToPreviousSpanIndex: true, Rate: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
+			EventDefaults:    EventDefaults{GenerateExceptionOnError: true, Rate: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
+		},
+		Spans: []SpanTemplate{
+			// do not change order of the first one
+			{Service: "test-service", Name: ptr("only_default")},
+			{Service: "test-service", Name: ptr("default_and_template"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{LinkToPreviousSpanIndex: true, Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}},
+			{Service: "test-service", Name: ptr("default_and_random"), RandomEvents: RandomEvents{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: RandomLinks{LinkToPreviousSpanIndex: false, Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
+			{Service: "test-service", Name: ptr("default_template_random"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{LinkToPreviousSpanIndex: true, Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}, RandomEvents: RandomEvents{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: RandomLinks{LinkToPreviousSpanIndex: false, Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
+			{Service: "test-service", Name: ptr("default_generate_on_error"), Attributes: map[string]interface{}{"http.status_code": 400}},
+		},
+	}
+
+	for _, semantics := range attributeSemantics {
+		template.Defaults.AttributeSemantics = &semantics
+		gen, err := NewTemplatedGenerator(&template)
+		assert.NoError(t, err)
+
+		for i := 0; i < testRounds; i++ {
+			traces := gen.Traces()
+			spans := collectSpansFromTrace(traces)
+
+			assert.Len(t, spans, len(template.Spans))
+			for i, span := range spans {
+				events := span.Events()
+				links := span.Links()
+				checkEventsLinksLength := func(spanIndex, expectedTemplate, expectedRandom int, spanName string) {
+					expected := expectedTemplate + expectedRandom
+					// because default rate is 0.5
+					if spanIndex%2 == 0 {
+						assert.Equal(t, expected+1, events.Len(), "test name: %s events", spanName)
+						assert.Equal(t, expected+1, links.Len(), "test name: %s links", spanName)
+					} else {
+						assert.Equal(t, expected, events.Len(), "test name: %s events", spanName)
+						assert.Equal(t, expected, links.Len(), "test name: %s links", spanName)
+					}
+				}
+
+				switch span.Name() {
+				case "only_default":
+					checkEventsLinksLength(i, 0, 0, span.Name())
+					if i%2 == 0 {
+						// check default event with 3 random attributes
+						event := events.At(0)
+						assert.Equal(t, 3, len(event.Attributes().AsRaw()))
+
+						// check default link with 3 random attributes
+						// and not matching trace id and parent span id because this is
+						// the first span, there is no previous span
+						link := links.At(0)
+						assert.Equal(t, 3, len(link.Attributes().AsRaw()))
+						assert.NotEqual(t, span.TraceID().String(), link.TraceID())
+						assert.NotEqual(t, span.ParentSpanID(), link.SpanID())
+					}
+				case "default_and_template":
+					checkEventsLinksLength(i, 1, 0, span.Name())
+				case "default_and_random":
+					checkEventsLinksLength(i, 0, 2, span.Name())
+				case "default_template_random":
+					checkEventsLinksLength(i, 1, 2, span.Name())
+				case "default_generate_on_error":
+					// # events and links should not match in this scenario
+					if i%2 == 0 {
+						assert.Equal(t, 2, events.Len())
+						assert.Equal(t, 1, links.Len())
+					} else {
+						assert.Equal(t, 1, events.Len())
+						assert.Equal(t, 0, links.Len())
+					}
+					found := false
+					for i := 0; i < events.Len(); i++ {
+						event := events.At(i)
+						if event.Name() == "exception" {
+							found = true
+							assert.NotNil(t, event.Attributes().AsRaw()["exception.escape"])
+							assert.NotNil(t, event.Attributes().AsRaw()["exception.message"])
+							assert.NotNil(t, event.Attributes().AsRaw()["exception.stacktrace"])
+							assert.NotNil(t, event.Attributes().AsRaw()["exception.type"])
+						}
+					}
+					assert.True(t, found, "exception event not found")
+				}
+			}
+		}
+	}
+}
+
 func attributesWithPrefix(span ptrace.Span, prefix string) int {
 	var count int
 	span.Attributes().Range(func(k string, _ pcommon.Value) bool {


### PR DESCRIPTION
test outputs against [tempo 3163](https://github.com/grafana/tempo/pull/3163)

added "event attribute" in [commit](https://github.com/grafana/xk6-client-tracing/pull/21/commits/017e400b329d3045b451dfd98484e818b727b1a2) to verify changes took place during testing

trace json from querying trace by id
```
"events": [
  {
      "timeUnixNano": "1703790751493000000",
      "name": "k6.z82CnPfdkFVs",
      "attributes": [
          {
              "key": "event attributek6.qrbAb",
              "value": {
                  "stringValue": "k6.tZLSTRQUJzo8"
              }
          }
      ]
  }
],
```

```
"links": [
  {
      "traceId": "K43tbrFZhQRSPbpFbe6irw==",
      "spanId": "aZQKClAJ5tc=",
      "attributes": [
          {
              "key": "k6.lgCDAL7OExDN",
              "value": {
                  "stringValue": "k6.2W4d5oKDI7nq"
              }
          }
      ]
  }
],
```

![Screenshot 2023-12-28 at 1 15 44 PM](https://github.com/grafana/xk6-client-tracing/assets/94262131/0742f978-b548-4ecf-b305-d13563c970be)
