### PR TITLE
Fix TLS struct keys and adjust field tags to match field names

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ The configuration is an object with the following schema:
     // The endpoint to which the traces are sent in the form of <hostname>:<port>
     endpoint: string,
     // The exporter protocol used for sending the traces: tracing.EXPORTER_OTLP or tracing.EXPORTER_JAEGER
-    exporter: string,
+    exporter: string, 
     // Whether insecure connections are allowed (optional, default: false)
-    insecure: bool,
+    tls: { insecure: true },
     // Credentials used for authentication
     authentication: { user: string, password: string },
     // Additional headers sent by the client

--- a/README.md
+++ b/README.md
@@ -29,13 +29,26 @@ The configuration is an object with the following schema:
     // The endpoint to which the traces are sent in the form of <hostname>:<port>
     endpoint: string,
     // The exporter protocol used for sending the traces: tracing.EXPORTER_OTLP or tracing.EXPORTER_JAEGER
-    exporter: string, 
-    // Whether insecure connections are allowed (optional, default: false)
-    tls: { insecure: true },
-    // Credentials used for authentication
+    exporter: string,
+    // Credentials used for authentication (optional)
     authentication: { user: string, password: string },
-    // Additional headers sent by the client
+    // Additional headers sent by the client (optional)
     headers: { string : string }
+    // TLS configuration
+    tls: {
+        // Whether insecure connections are allowed (optional, default: false)
+        insecure: boolean,
+        // Enable TLS but skip verification (optional, default: false)
+        insecure_skip_verify: boolean,
+        // The server name requested by the client (optional)
+        server_name: string,
+        // The path to the CA certificate file (optional)
+        ca_file: string,
+        // The path to the certificate file (optional)
+        cert_file: string,
+        // The path to the key file (optional)
+        key_file: string,
+    },
 }
 ```
 

--- a/examples/param/param.js
+++ b/examples/param/param.js
@@ -11,7 +11,6 @@ const endpoint = __ENV.ENDPOINT || "otel-collector:4317"
 const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,
-    insecure: true,
     tls: {
       insecure: false,
     }

--- a/examples/param/param.js
+++ b/examples/param/param.js
@@ -12,6 +12,9 @@ const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,
     insecure: true,
+    tls: {
+      insecure: false,
+    }
 });
 
 export default function () {

--- a/examples/param/param.js
+++ b/examples/param/param.js
@@ -12,7 +12,7 @@ const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,
     tls: {
-      insecure: false,
+      insecure: true,
     }
 });
 

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -12,7 +12,9 @@ const orgid = __ENV.TEMPO_X_SCOPE_ORGID || "k6-test"
 const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,
-    insecure: true,
+    tls: {
+      insecure: false,
+    },
     headers: {
         "X-Scope-Orgid": orgid
     }

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -13,7 +13,7 @@ const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,
     tls: {
-      insecure: false,
+      insecure: true,
     },
     headers: {
         "X-Scope-Orgid": orgid

--- a/tracing.go
+++ b/tracing.go
@@ -144,23 +144,23 @@ func (ct *TracingModule) newTemplatedGenerator(g goja.ConstructorCall, rt *goja.
 }
 
 type TLSClientConfig struct {
-	Insecure           bool   `json:"insecure"`
-	InsecureSkipVerify bool   `json:"insecure_skip_verify"`
-	ServerName         string `json:"server_name_override"`
-	CAFile             string `json:"ca_file"`
-	CertFile           string `json:"cert_file"`
-	KeyFile            string `json:"key_file"`
+	Insecure           bool   `js:"insecure"`
+	InsecureSkipVerify bool   `js:"insecure_skip_verify"`
+	ServerName         string `js:"server_name"`
+	CAFile             string `js:"ca_file"`
+	CertFile           string `js:"cert_file"`
+	KeyFile            string `js:"key_file"`
 }
 
 type ClientConfig struct {
-	Exporter       exporterType    `json:"type"`
-	Endpoint       string          `json:"url"`
-	TLS            TLSClientConfig `json:"tls"`
+	Exporter       exporterType    `js:"exporter"`
+	Endpoint       string          `js:"endpoint"`
+	TLS            TLSClientConfig `js:"tls"`
 	Authentication struct {
-		User     string `json:"user"`
-		Password string `json:"password"`
+		User     string `js:"user"`
+		Password string `js:"password"`
 	}
-	Headers map[string]configopaque.String `json:"headers"`
+	Headers map[string]configopaque.String `js:"headers"`
 }
 
 type Client struct {

--- a/tracing.go
+++ b/tracing.go
@@ -143,10 +143,19 @@ func (ct *TracingModule) newTemplatedGenerator(g goja.ConstructorCall, rt *goja.
 	return rt.ToValue(generator).ToObject(rt)
 }
 
+type TLSClientConfig struct {
+	Insecure           bool   `json:"insecure"`
+	InsecureSkipVerify bool   `json:"insecure_skip_verify"`
+	ServerName         string `json:"server_name_override"`
+	CAFile             string `json:"ca_file"`
+	CertFile           string `json:"cert_file"`
+	KeyFile            string `json:"key_file"`
+}
+
 type ClientConfig struct {
-	Exporter       exporterType               `json:"type"`
-	Endpoint       string                     `json:"url"`
-	TLS            configtls.TLSClientSetting `json:"tls"`
+	Exporter       exporterType    `json:"type"`
+	Endpoint       string          `json:"url"`
+	TLS            TLSClientConfig `json:"tls"`
 	Authentication struct {
 		User     string `json:"user"`
 		Password string `json:"password"`

--- a/tracing.go
+++ b/tracing.go
@@ -179,8 +179,9 @@ func NewClient(cfg *ClientConfig, vu modules.VU) (*Client, error) {
 	)
 
 	tlsConfig := configtls.TLSClientSetting{
-		Insecure:   cfg.TLS.Insecure,
-		ServerName: cfg.TLS.ServerName,
+		Insecure:           cfg.TLS.Insecure,
+		InsecureSkipVerify: cfg.TLS.InsecureSkipVerify,
+		ServerName:         cfg.TLS.ServerName,
 		TLSSetting: configtls.TLSSetting{
 			CAFile:   cfg.TLS.CAFile,
 			CertFile: cfg.TLS.CertFile,


### PR DESCRIPTION
The previous update to enable TLS config settings leveraged existing structs which, when mapped from JS -> Golang, did not end up with a friendly user interface.  Here we clean up the struct fields after reading the following docs.

https://grafana.com/docs/k6/latest/extensions/explanations/go-js-bridge/#about-the-go-to-js-bridge

Also update the docker examples to match the new struct keys.