### PR TITLE
Refactor templated event and link generation

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -12,13 +12,13 @@ jobs:
       - name: Set-up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.21
+          go-version: ^1.22
           cache: true
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.55.2
+          version: v1.59.0
           args: --config ./golangci.yml
 
       - name: Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set-up Go
         uses: actions/setup-go@v3
         with:
-          go-version: ^1.19
+          go-version: ^1.22
           cache: true
 
       - name: Test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine AS xk6-client-tracing-build
+FROM golang:1.22-alpine AS xk6-client-tracing-build
 
 RUN apk add --no-cache \
     build-base \
@@ -7,7 +7,7 @@ RUN apk add --no-cache \
     make
 
 RUN go install go.k6.io/xk6/cmd/xk6@latest \
-    && wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.50.0 \
+    && wget -O- -nv https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s v1.59.0 \
     && golangci-lint --version
 
 WORKDIR /opt/xk6-client-tracing

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -3,7 +3,7 @@ import tracing from 'k6/x/tracing';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export const options = {
-    vus: 1,
+    vus: 4,
     duration: "20m",
 };
 
@@ -13,7 +13,7 @@ const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,
     tls: {
-      insecure: true,
+        insecure: true,
     },
     headers: {
         "X-Scope-Orgid": orgid
@@ -25,7 +25,6 @@ const traceDefaults = {
     attributes: {"one": "three"},
     randomAttributes: {count: 2, cardinality: 5},
     randomEvents: {generateExceptionOnError: true, rate: 1.0, randomAttributes: {count: 2, cardinality: 3}},
-    randomLinks: {rate: 1.0, randomAttributes: {count: 2, cardinality: 3}},
 }
 
 const traceTemplates = [
@@ -36,7 +35,7 @@ const traceTemplates = [
             {service: "shop-backend", name: "authenticate", duration: {min: 50, max: 100}},
             {service: "auth-service", name: "authenticate"},
             {service: "shop-backend", name: "fetch-articles", parentIdx: 0},
-            {service: "article-service", name: "list-articles"},
+            {service: "article-service", name: "list-articles", links: [{attributes: {"link-type": "parent-child"}, randomAttributes: {count: 2, cardinality: 5}}]},
             {service: "article-service", name: "select-articles", attributeSemantics: tracing.SEMANTICS_DB},
             {service: "postgres", name: "query-articles", attributeSemantics: tracing.SEMANTICS_DB, randomAttributes: {count: 5}},
         ]
@@ -74,7 +73,7 @@ const traceTemplates = [
             {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
             {service: "auth-service", name: "authenticate", attributes: {"http.status_code": 403}},
             {service: "cart-service", name: "checkout", randomEvents: {exceptionRate: 1, rate: 2, randomAttributes: {count: 5, cardinality: 2}}},
-            {service: "billing-service", name: "payment", randomLinks: {rate: 2, randomAttributes: {count: 3, cardinality: 2}}}
+            {service: "billing-service", name: "payment", randomLinks: {count: 0.5, randomAttributes: {count: 3, cardinality: 10}}}
         ]
     },
 ]

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -44,6 +44,7 @@ const traceTemplates = [
         defaults: {
             attributes: {"numbers": ["one", "two", "three"]},
             attributeSemantics: tracing.SEMANTICS_HTTP,
+            randomEvents: {count: 2, randomAttributes: {count: 3, cardinality: 10}},
         },
         spans: [
             {service: "shop-backend", name: "article-to-cart", duration: {min: 400, max: 1200}},
@@ -63,17 +64,17 @@ const traceTemplates = [
         spans: [
             {service: "shop-backend", attributes: {"http.status_code": 403}},
             {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
-            {service: "auth-service", name: "authenticate", attributes: {"http.status_code": 403}},
+            {service: "auth-service", name: "authenticate", attributes: {"http.status_code": 403}, randomEvents: {count: 0.5, exceptionCount: 2, randomAttributes: {count: 5, cardinality: 5}}},
         ]
     },
     {
         defaults: traceDefaults,
         spans: [
-            {service: "shop-backend", attributes: {"http.status_code": 403}},
+            {service: "shop-backend"},
             {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
-            {service: "auth-service", name: "authenticate", attributes: {"http.status_code": 403}},
-            {service: "cart-service", name: "checkout", randomEvents: {exceptionRate: 1, rate: 2, randomAttributes: {count: 5, cardinality: 2}}},
-            {service: "billing-service", name: "payment", randomLinks: {count: 0.5, randomAttributes: {count: 3, cardinality: 10}}}
+            {service: "auth-service", name: "authenticate"},
+            {service: "cart-service", name: "checkout", randomEvents: {count: 0.5, exceptionCount: 2, exceptionOnError: true, randomAttributes: {count: 5, cardinality: 5}}},
+            {service: "billing-service", name: "payment", randomLinks: {count: 0.5, randomAttributes: {count: 3, cardinality: 10}}, randomEvents: {exceptionOnError: true, randomAttributes: {count: 4}}}
         ]
     },
 ]

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -3,7 +3,7 @@ import tracing from 'k6/x/tracing';
 import { randomIntBetween } from 'https://jslib.k6.io/k6-utils/1.2.0/index.js';
 
 export const options = {
-    vus: 4,
+    vus: 1,
     duration: "20m",
 };
 
@@ -24,7 +24,7 @@ const traceDefaults = {
     attributeSemantics: tracing.SEMANTICS_HTTP,
     attributes: {"one": "three"},
     randomAttributes: {count: 2, cardinality: 5},
-    randomEvents: {generateExceptionOnError: true, rate: 1.0, randomAttributes: {count: 2, cardinality: 3}},
+    randomEvents: {count: 0.1, exceptionCount: 0.2, randomAttributes: {count: 6, cardinality: 20}},
 }
 
 const traceTemplates = [
@@ -35,7 +35,11 @@ const traceTemplates = [
             {service: "shop-backend", name: "authenticate", duration: {min: 50, max: 100}},
             {service: "auth-service", name: "authenticate"},
             {service: "shop-backend", name: "fetch-articles", parentIdx: 0},
-            {service: "article-service", name: "list-articles", links: [{attributes: {"link-type": "parent-child"}, randomAttributes: {count: 2, cardinality: 5}}]},
+            {
+                service: "article-service",
+                name: "list-articles",
+                links: [{attributes: {"link-type": "parent-child"}, randomAttributes: {count: 2, cardinality: 5}}]
+            },
             {service: "article-service", name: "select-articles", attributeSemantics: tracing.SEMANTICS_DB},
             {service: "postgres", name: "query-articles", attributeSemantics: tracing.SEMANTICS_DB, randomAttributes: {count: 5}},
         ]
@@ -64,7 +68,12 @@ const traceTemplates = [
         spans: [
             {service: "shop-backend", attributes: {"http.status_code": 403}},
             {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
-            {service: "auth-service", name: "authenticate", attributes: {"http.status_code": 403}, randomEvents: {count: 0.5, exceptionCount: 2, randomAttributes: {count: 5, cardinality: 5}}},
+            {
+                service: "auth-service",
+                name: "authenticate",
+                attributes: {"http.status_code": 403},
+                randomEvents: {count: 0.5, exceptionCount: 2, randomAttributes: {count: 5, cardinality: 5}}
+            },
         ]
     },
     {
@@ -73,8 +82,16 @@ const traceTemplates = [
             {service: "shop-backend"},
             {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
             {service: "auth-service", name: "authenticate"},
-            {service: "cart-service", name: "checkout", randomEvents: {count: 0.5, exceptionCount: 2, exceptionOnError: true, randomAttributes: {count: 5, cardinality: 5}}},
-            {service: "billing-service", name: "payment", randomLinks: {count: 0.5, randomAttributes: {count: 3, cardinality: 10}}, randomEvents: {exceptionOnError: true, randomAttributes: {count: 4}}}
+            {
+                service: "cart-service",
+                name: "checkout",
+                randomEvents: {count: 0.5, exceptionCount: 2, exceptionOnError: true, randomAttributes: {count: 5, cardinality: 5}}
+            },
+            {
+                service: "billing-service",
+                name: "payment",
+                randomLinks: {count: 0.5, randomAttributes: {count: 3, cardinality: 10}},
+                randomEvents: {exceptionOnError: true, randomAttributes: {count: 4}}}
         ]
     },
 ]

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -125,3 +125,7 @@ func SpanID() pcommon.SpanID {
 	_, _ = rnd.Read(b[:]) // always returns nil error
 	return b
 }
+
+func EventName() string {
+	return "event_k6." + String(10)
+}

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -32,6 +32,10 @@ func init() {
 	rnd = rand.New(rand.NewSource(seed.Int64()))
 }
 
+func Rand() *rand.Rand {
+	return rnd
+}
+
 func SelectElement[T any](elements []T) T {
 	return elements[rnd.Intn(len(elements))]
 }

--- a/pkg/tracegen/templated.go
+++ b/pkg/tracegen/templated.go
@@ -700,39 +700,6 @@ func (g *TemplatedGenerator) initializeEvents(tmplEvents []Event, randomEvents, 
 	return internalEvents
 }
 
-func generateExceptionEvent() Event {
-	return Event{
-		Name: "exception",
-		Attributes: map[string]interface{}{
-			"exception.escape":     false,
-			"exception.message":    generateRandomExceptionMsg(),
-			"exception.stacktrace": generateRandomExceptionStackTrace(),
-			"exception.type":       random.K6String(10) + ".error",
-		},
-	}
-}
-
-func generateEvent(name string, attributes map[string]interface{}, randomAttr *AttributeParams) Event {
-	event := Event{
-		Attributes: make(map[string]interface{}),
-	}
-
-	if name != "" {
-		event.Name = name
-	} else {
-		event.Name = "event " + random.K6String(10)
-	}
-
-	for k, v := range attributes {
-		event.Attributes[k] = v
-	}
-
-	for k, v := range initializeRandomAttributes(randomAttr) {
-		event.Attributes[k] = random.SelectElement(v)
-	}
-	return event
-}
-
 func generateRandomExceptionMsg() string {
 	return "error: " + random.K6String(20)
 }

--- a/pkg/tracegen/templated.go
+++ b/pkg/tracegen/templated.go
@@ -654,14 +654,14 @@ func (g *TemplatedGenerator) initializeEvents(tmplEvents []Event, randomEvents, 
 	if randomEvents.Count < 1 {
 		event := internalEventTemplate{
 			rate:             randomEvents.Count,
-			name:             "event_" + random.K6String(10),
+			name:             random.EventName(),
 			randomAttributes: initializeRandomAttributes(randomEvents.RandomAttributes),
 		}
 		internalEvents = append(internalEvents, event)
 	} else {
 		for i := 0; i < int(randomEvents.Count); i++ {
 			event := internalEventTemplate{
-				name:             "event_" + random.K6String(10),
+				name:             random.EventName(),
 				randomAttributes: initializeRandomAttributes(randomEvents.RandomAttributes),
 			}
 			internalEvents = append(internalEvents, event)
@@ -675,7 +675,7 @@ func (g *TemplatedGenerator) initializeEvents(tmplEvents []Event, randomEvents, 
 	if randomEvents.ExceptionCount < 1 {
 		event := internalEventTemplate{
 			rate:             randomEvents.Count,
-			name:             "event_" + random.K6String(10),
+			name:             random.EventName(),
 			randomAttributes: initializeRandomAttributes(randomEvents.RandomAttributes),
 			exceptionOnError: randomEvents.ExceptionOnError,
 		}
@@ -688,7 +688,7 @@ func (g *TemplatedGenerator) initializeEvents(tmplEvents []Event, randomEvents, 
 					"exception.escape":     false,
 					"exception.message":    generateRandomExceptionMsg(),
 					"exception.stacktrace": generateRandomExceptionStackTrace(),
-					"exception.type":       random.K6String(10) + ".error",
+					"exception.type":       "error.type_" + random.K6String(10),
 				},
 				randomAttributes: initializeRandomAttributes(randomEvents.RandomAttributes),
 				exceptionOnError: randomEvents.ExceptionOnError,

--- a/pkg/tracegen/templated.go
+++ b/pkg/tracegen/templated.go
@@ -674,8 +674,14 @@ func (g *TemplatedGenerator) initializeEvents(tmplEvents []Event, randomEvents, 
 	}
 	if randomEvents.ExceptionCount < 1 {
 		event := internalEventTemplate{
-			rate:             randomEvents.Count,
-			name:             random.EventName(),
+			rate: randomEvents.ExceptionCount,
+			name: "exception",
+			attributes: map[string]interface{}{
+				"exception.escape":     false,
+				"exception.message":    generateRandomExceptionMsg(),
+				"exception.stacktrace": generateRandomExceptionStackTrace(),
+				"exception.type":       "error.type_" + random.K6String(10),
+			},
 			randomAttributes: initializeRandomAttributes(randomEvents.RandomAttributes),
 			exceptionOnError: randomEvents.ExceptionOnError,
 		}

--- a/pkg/tracegen/templated.go
+++ b/pkg/tracegen/templated.go
@@ -121,10 +121,10 @@ type LinkParams struct {
 type EventParams struct {
 	// Generate exception event if status code of the span is >= 400
 	GenerateExceptionOnError bool `js:"generateExceptionOnError"`
-	// Rate of exception events per each span
+	// Count of exception events per each span
 	ExceptionRate float32 `js:"exceptionRate"`
-	// Rate of random events per each span
-	Rate float32 `js:"rate"`
+	// Count of random events per each span
+	Count float32 `js:"count"`
 	// Generate random attributes for this event
 	RandomAttributes *AttributeParams `js:"randomAttributes"`
 }
@@ -178,10 +178,9 @@ type internalLinkTemplate struct {
 }
 
 type internalEventTemplate struct {
-	count                    int
-	generateExceptionOnError bool
-	exceptionCount           int
-	randomAttributes         *AttributeParams
+	count            int
+	exceptionCount   int
+	randomAttributes *AttributeParams
 }
 
 // Traces implements Generator for TemplatedGenerator
@@ -534,15 +533,14 @@ func (g *TemplatedGenerator) initializeSpan(idx int, parent *internalSpanTemplat
 	}
 	span.attributes = util.MergeMaps(defaults.Attributes, tmpl.Attributes)
 
-	eventDefaultsRate := defaults.RandomEvents.Rate
+	eventDefaultsRate := defaults.RandomEvents.Count
 	var eventDefaults internalEventTemplate
 	// if rate is more than 1, use whole integers
 	if eventDefaultsRate > 1 {
 		eventDefaults = internalEventTemplate{
-			generateExceptionOnError: defaults.RandomEvents.GenerateExceptionOnError,
-			randomAttributes:         defaults.RandomEvents.RandomAttributes,
-			count:                    int(eventDefaultsRate),
-			exceptionCount:           int(defaults.RandomEvents.ExceptionRate),
+			randomAttributes: defaults.RandomEvents.RandomAttributes,
+			count:            int(eventDefaultsRate),
+			exceptionCount:   int(defaults.RandomEvents.ExceptionRate),
 		}
 	} else {
 		var count, exeptionCount int
@@ -556,18 +554,16 @@ func (g *TemplatedGenerator) initializeSpan(idx int, parent *internalSpanTemplat
 
 		// if rate is less than one
 		eventDefaults = internalEventTemplate{
-			generateExceptionOnError: defaults.RandomEvents.GenerateExceptionOnError,
-			randomAttributes:         defaults.RandomEvents.RandomAttributes,
-			count:                    count,
-			exceptionCount:           exeptionCount,
+			randomAttributes: defaults.RandomEvents.RandomAttributes,
+			count:            count,
+			exceptionCount:   exeptionCount,
 		}
 	}
 
 	randomEvents := internalEventTemplate{
-		generateExceptionOnError: tmpl.RandomEvents.GenerateExceptionOnError,
-		randomAttributes:         tmpl.RandomEvents.RandomAttributes,
-		count:                    int(tmpl.RandomEvents.Rate),
-		exceptionCount:           int(tmpl.RandomEvents.ExceptionRate),
+		randomAttributes: tmpl.RandomEvents.RandomAttributes,
+		count:            int(tmpl.RandomEvents.Count),
+		exceptionCount:   int(tmpl.RandomEvents.ExceptionRate),
 	}
 
 	// generate all non-exception events

--- a/pkg/tracegen/templated_test.go
+++ b/pkg/tracegen/templated_test.go
@@ -58,15 +58,15 @@ func TestTemplatedGenerator_EventsLinks(t *testing.T) {
 		Defaults: SpanDefaults{
 			Attributes:       map[string]interface{}{"fixed.attr": "some-value"},
 			RandomAttributes: &AttributeParams{Count: 3},
-			RandomLinks:      LinkParams{Rate: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
+			RandomLinks:      &LinkParams{Count: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
 			RandomEvents:     EventParams{GenerateExceptionOnError: true, Rate: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
 		},
 		Spans: []SpanTemplate{
 			// do not change order of the first one
 			{Service: "test-service", Name: ptr("only_default")},
 			{Service: "test-service", Name: ptr("default_and_template"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}},
-			{Service: "test-service", Name: ptr("default_and_random"), RandomEvents: EventParams{Rate: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: LinkParams{Rate: 2, RandomAttributes: &AttributeParams{Count: 1}}},
-			{Service: "test-service", Name: ptr("default_template_random"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}, RandomEvents: EventParams{Rate: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: LinkParams{Rate: 2, RandomAttributes: &AttributeParams{Count: 1}}},
+			{Service: "test-service", Name: ptr("default_and_random"), RandomEvents: EventParams{Rate: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
+			{Service: "test-service", Name: ptr("default_template_random"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}, RandomEvents: EventParams{Rate: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
 			{Service: "test-service", Name: ptr("default_generate_on_error"), Attributes: map[string]interface{}{"http.status_code": 400}},
 		},
 	}

--- a/pkg/tracegen/templated_test.go
+++ b/pkg/tracegen/templated_test.go
@@ -59,14 +59,14 @@ func TestTemplatedGenerator_EventsLinks(t *testing.T) {
 			Attributes:       map[string]interface{}{"fixed.attr": "some-value"},
 			RandomAttributes: &AttributeParams{Count: 3},
 			RandomLinks:      &LinkParams{Count: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
-			RandomEvents:     EventParams{GenerateExceptionOnError: true, Rate: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
+			RandomEvents:     EventParams{GenerateExceptionOnError: true, Count: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
 		},
 		Spans: []SpanTemplate{
 			// do not change order of the first one
 			{Service: "test-service", Name: ptr("only_default")},
 			{Service: "test-service", Name: ptr("default_and_template"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}},
-			{Service: "test-service", Name: ptr("default_and_random"), RandomEvents: EventParams{Rate: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
-			{Service: "test-service", Name: ptr("default_template_random"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}, RandomEvents: EventParams{Rate: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
+			{Service: "test-service", Name: ptr("default_and_random"), RandomEvents: EventParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
+			{Service: "test-service", Name: ptr("default_template_random"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}, RandomEvents: EventParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
 			{Service: "test-service", Name: ptr("default_generate_on_error"), Attributes: map[string]interface{}{"http.status_code": 400}},
 		},
 	}

--- a/pkg/tracegen/templated_test.go
+++ b/pkg/tracegen/templated_test.go
@@ -59,14 +59,14 @@ func TestTemplatedGenerator_EventsLinks(t *testing.T) {
 			Attributes:       map[string]interface{}{"fixed.attr": "some-value"},
 			RandomAttributes: &AttributeParams{Count: 3},
 			RandomLinks:      &LinkParams{Count: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
-			RandomEvents:     EventParams{GenerateExceptionOnError: true, Count: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
+			RandomEvents:     &EventParams{ExceptionOnError: true, Count: 0.5, RandomAttributes: &AttributeParams{Count: 3}},
 		},
 		Spans: []SpanTemplate{
 			// do not change order of the first one
 			{Service: "test-service", Name: ptr("only_default")},
 			{Service: "test-service", Name: ptr("default_and_template"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}},
-			{Service: "test-service", Name: ptr("default_and_random"), RandomEvents: EventParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
-			{Service: "test-service", Name: ptr("default_template_random"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}, RandomEvents: EventParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
+			{Service: "test-service", Name: ptr("default_and_random"), RandomEvents: &EventParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
+			{Service: "test-service", Name: ptr("default_template_random"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}, RandomEvents: &EventParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
 			{Service: "test-service", Name: ptr("default_generate_on_error"), Attributes: map[string]interface{}{"http.status_code": 400}},
 		},
 	}

--- a/tracing.go
+++ b/tracing.go
@@ -1,4 +1,4 @@
-package xk6_client_tracing
+package clienttracing
 
 import (
 	"context"


### PR DESCRIPTION
This PR makes the initialization phase and generation phase of events and links more similar to the initialization and generation of resources and spans.

Additionally the PR makes the following changes:
* Event times now have a random offset
* Attributes for random events and links now take the cardinality parameter into account
* The template.js example creates a diverse range of events, exceptions and links
* Update to the latest Go and golangci-lint version