### PR TITLE
Correct OTel tracestate format

### DIFF
--- a/pkg/tracegen/parameterized.go
+++ b/pkg/tracegen/parameterized.go
@@ -122,7 +122,7 @@ func (g *ParameterizedGenerator) generateSpan(t *TraceParams, dest ptrace.Span) 
 	span.SetKind(ptrace.SpanKindClient)
 	span.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
 	span.SetEndTimestamp(pcommon.NewTimestampFromTime(endTime))
-	span.TraceState().FromRaw("x:y")
+	span.TraceState().FromRaw("ot=x:y")
 
 	event := span.Events().AppendEmpty()
 	event.SetName(random.K6String(12))


### PR DESCRIPTION
Correct the tracestate value as the OpenTelemetry mandates to have the `ot` key:

> When setting [TraceState](https://opentelemetry.io/docs/specs/otel/trace/api/#tracestate) values that are part of the OTel ecosystem, they MUST all be contained in a single entry using the ot key, with the value being a semicolon separated list of key-value pairs such as:
> 
> ot=p:8;r:62
> ot=foo:bar;k1:13

Fixes #40