### PR TITLE
[ParameterizedGenerator] Add resource size and count to trace params

### DIFF
--- a/examples/param/param.js
+++ b/examples/param/param.js
@@ -12,23 +12,25 @@ const client = new tracing.Client({
     endpoint,
     exporter: tracing.EXPORTER_OTLP,
     tls: {
-      insecure: true,
+        insecure: true,
     }
 });
 
 export default function () {
-    let pushSizeTraces = randomIntBetween(2,3);
+    let pushSizeTraces = randomIntBetween(2, 3);
     let pushSizeSpans = 0;
     let t = [];
     for (let i = 0; i < pushSizeTraces; i++) {
-        let c = randomIntBetween(5,10)
+        let c = randomIntBetween(5, 10)
         pushSizeSpans += c;
 
         t.push({
             random_service_name: false,
+            count: 1,
+            resource_size: 100,
             spans: {
                 count: c,
-                size: randomIntBetween(300,1000),
+                size: randomIntBetween(300, 1000),
                 random_name: true,
                 fixed_attrs: {
                     "test": "test",


### PR DESCRIPTION
This is useful for testing the impact of "shard-by-trace-id" architectures.

Previously, all exported batches only included a single trace, which means they always end up in the same shard. Now it's possible to touch multiple shards per export request, which in some cases is important to properly demonstrate the downstream system's performance.