### PR TITLE
[TemplatedGenerator] Fix span template attribute semantic

### DIFF
--- a/pkg/tracegen/templated.go
+++ b/pkg/tracegen/templated.go
@@ -568,14 +568,15 @@ func (g *TemplatedGenerator) amendInitializedResource(res *internalResourceTempl
 func (g *TemplatedGenerator) initializeSpan(idx int, parent *internalSpanTemplate, defaults *SpanDefaults, tmpl, child *SpanTemplate) (*internalSpanTemplate, error) {
 	res := g.resources[tmpl.Service]
 	span := internalSpanTemplate{
-		idx:      idx,
-		parent:   parent,
-		resource: res,
-		duration: tmpl.Duration,
+		idx:                idx,
+		parent:             parent,
+		resource:           res,
+		duration:           tmpl.Duration,
+		attributeSemantics: tmpl.AttributeSemantics,
 	}
 
 	// apply defaults
-	if tmpl.AttributeSemantics == nil {
+	if span.attributeSemantics == nil {
 		span.attributeSemantics = defaults.AttributeSemantics
 	}
 	span.attributes = util.MergeMaps(defaults.Attributes, tmpl.Attributes)


### PR DESCRIPTION
Fix a small issue in the `TemplatedGenerator` where a `SpanTemplate.AttributeSemantics` is not taken into account, only the default semantic is used in the `initializeSpan` function.

One example is when you have a default semantic of `SemanticsDB` (to generate a trace that is mostly DB intensive) and then want to use `SemanticsHTTP` in some spans, then most of the HTTP attributes are not generated.