### PR TITLE
Use more recent OTEL semantic conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The following listing creates a generator that creates traces with a single span
 ```javascript
 const template = {
     spans: [
-        {service: "article-service", name: "get-articles", attributes: {"http.method": "GET"}}
+        {service: "article-service", name: "get-articles", attributes: {"http.request.method": "GET"}}
     ]
 };
 let gen = new tracing.TemplatedGenerator(template);

--- a/examples/template/template.js
+++ b/examples/template/template.js
@@ -61,19 +61,19 @@ const traceTemplates = [
             {service: "article-service", name: "select-articles", attributeSemantics: tracing.SEMANTICS_DB},
             {service: "postgres", name: "query-articles", attributeSemantics: tracing.SEMANTICS_DB, randomAttributes: {count: 2}},
             {service: "shop-backend", name: "place-articles", parentIdx: 0},
-            {service: "cart-service", name: "place-articles", attributes: {"article.count": 1, "http.status_code": 201}},
+            {service: "cart-service", name: "place-articles", attributes: {"article.count": 1, "http.response.status_code": 201}},
             {service: "cart-service", name: "persist-cart"}
         ]
     },
     {
         defaults: traceDefaults,
         spans: [
-            {service: "shop-backend", attributes: {"http.status_code": 403}},
+            {service: "shop-backend", attributes: {"http.response.status_code": 403}},
             {service: "shop-backend", name: "authenticate", attributes: {"http.request.header.accept": ["application/json"]}},
             {
                 service: "auth-service",
                 name: "authenticate",
-                attributes: {"http.status_code": 403},
+                attributes: {"http.status_code": 403}, // use legacy attribute name to generate more heterogeneous traces
                 randomEvents: {count: 0.5, exceptionCount: 2, randomAttributes: {count: 5, cardinality: 5}}
             },
         ]
@@ -93,7 +93,8 @@ const traceTemplates = [
                 service: "billing-service",
                 name: "payment",
                 randomLinks: {count: 0.5, randomAttributes: {count: 3, cardinality: 10}},
-                randomEvents: {exceptionOnError: true, randomAttributes: {count: 4}}}
+                randomEvents: {exceptionOnError: true, randomAttributes: {count: 4}}
+            }
         ]
     },
 ]

--- a/golangci.yml
+++ b/golangci.yml
@@ -28,3 +28,7 @@ issues:
     - "var-naming: don't use an underscore in package name"
     - "redefines-builtin-id: redefinition of the built-in function max"
     - "redefines-builtin-id: redefinition of the built-in function min"
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - unparam

--- a/pkg/tracegen/parameterized.go
+++ b/pkg/tracegen/parameterized.go
@@ -79,7 +79,7 @@ func (g *ParameterizedGenerator) Traces() ptrace.Traces {
 		resourceAttributes := g.constructAttributes(te.ResourceSize)
 		resourceAttributes.CopyTo(rspan.Resource().Attributes())
 		rspan.Resource().Attributes().PutStr("k6", "true")
-		rspan.Resource().Attributes().PutStr("service.name", serviceName)
+		rspan.Resource().Attributes().PutStr(attrServiceName, serviceName)
 
 		ilss := rspan.ScopeSpans()
 		ilss.EnsureCapacity(1)

--- a/pkg/tracegen/parameterized_test.go
+++ b/pkg/tracegen/parameterized_test.go
@@ -36,7 +36,7 @@ func TestParameterizedGenerator_Traces(t *testing.T) {
 	// Validate resource span
 	rs := traces.ResourceSpans().At(0)
 	attrs := rs.Resource().Attributes()
-	_, hasServiceName := attrs.Get("service.name")
+	_, hasServiceName := attrs.Get(attrServiceName)
 	_, hasK6 := attrs.Get("k6")
 	assert.True(t, hasServiceName, "Should have service.name attribute")
 	assert.True(t, hasK6, "Should have k6 attribute")

--- a/pkg/tracegen/templated.go
+++ b/pkg/tracegen/templated.go
@@ -246,7 +246,7 @@ func (g *TemplatedGenerator) Traces() ptrace.Traces {
 func (g *TemplatedGenerator) generateResourceSpans(resSpanSlice ptrace.ResourceSpansSlice, tmpl *internalResourceTemplate) ptrace.ResourceSpans {
 	resSpans := resSpanSlice.AppendEmpty()
 	resSpans.Resource().Attributes().PutStr("k6", "true")
-	resSpans.Resource().Attributes().PutStr("service.name", tmpl.service)
+	resSpans.Resource().Attributes().PutStr(attrServiceName, tmpl.service)
 
 	for k, v := range tmpl.attributes {
 		_ = resSpans.Resource().Attributes().PutEmpty(k).FromRaw(v)
@@ -314,10 +314,8 @@ func (g *TemplatedGenerator) generateSpan(scopeSpans ptrace.ScopeSpans, tmpl *in
 
 	// generate events
 	var hasError bool
-	if st, found := span.Attributes().Get("http.status_code"); found {
-		hasError = st.Int() >= 400
-	} else if st, found = span.Attributes().Get("http.response.status_code"); found {
-		hasError = st.Int() >= 400
+	if st, found := getHTTPStatusCode(span.Attributes()); found {
+		hasError = st >= 400
 	}
 
 	span.Events().EnsureCapacity(len(tmpl.events))
@@ -406,35 +404,32 @@ func (g *TemplatedGenerator) generateHTTPAttributes(tmpl *internalSpanTemplate, 
 		parentAttr = parent.Attributes()
 	}
 
-	putIfNotExists(span.Attributes(), "http.flavor", "1.1")
+	putIfNotExists(span.Attributes(), "network.protocol.name", "http")
+	putIfNotExists(span.Attributes(), "network.protocol.version", "1.1")
 
 	if tmpl.kind == ptrace.SpanKindServer {
 		var method string
-		if m, found := span.Attributes().Get("http.method"); found {
-			method = m.Str()
-		} else if m, found = parentAttr.Get("http.method"); found {
-			method = m.Str()
+		if m, found := getHTTPMethod(span.Attributes()); found {
+			method = m
 		} else {
 			method = random.HTTPMethod()
-			span.Attributes().PutStr("http.method", method)
+			span.Attributes().PutStr(attrHTTPMethod, method)
 		}
 
 		var contentType []any
-		if ct, found := span.Attributes().Get("http.response.header.content-type"); found {
+		if ct, found := span.Attributes().Get(attrHTTPResponseHeaderContentType); found {
 			contentType = ct.Slice().AsRaw()
 		} else {
 			contentType = random.HTTPContentType()
-			_ = span.Attributes().PutEmptySlice("http.response.header.content-type").FromRaw(contentType)
+			_ = span.Attributes().PutEmptySlice(attrHTTPResponseHeaderContentType).FromRaw(contentType)
 		}
 
 		var status int64
-		if st, found := span.Attributes().Get("http.status_code"); found {
-			status = st.Int()
-		} else if st, found = parentAttr.Get("http.status_code"); found {
-			status = st.Int()
+		if st, found := getHTTPStatusCode(span.Attributes()); found {
+			status = st
 		} else {
 			status = random.HTTPStatusSuccess()
-			span.Attributes().PutInt("http.status_code", status)
+			span.Attributes().PutInt(attrHTTPStatusCode, status)
 		}
 		if status >= 500 {
 			span.Status().SetCode(ptrace.StatusCodeError)
@@ -442,20 +437,20 @@ func (g *TemplatedGenerator) generateHTTPAttributes(tmpl *internalSpanTemplate, 
 		}
 
 		var requestURL *url.URL
-		if u, found := span.Attributes().Get("http.url"); found {
+		if u, found := span.Attributes().Get(attrURL); found {
 			requestURL, _ = url.ParseRequestURI(u.Str())
-		} else if u, found = parentAttr.Get("http.url"); found {
+		} else if u, found = parentAttr.Get(attrURL); found {
 			requestURL, _ = url.ParseRequestURI(u.Str())
 		} else {
 			requestURL, _ = url.ParseRequestURI(fmt.Sprintf("https://%s:%d/%s", tmpl.resource.hostName, tmpl.resource.hostPort, tmpl.name))
-			span.Attributes().PutStr("http.url", requestURL.String())
+			span.Attributes().PutStr(attrURL, requestURL.String())
 		}
-		span.Attributes().PutStr("http.scheme", requestURL.Scheme)
-		span.Attributes().PutStr("http.target", requestURL.Path)
+		span.Attributes().PutStr(attrURLScheme, requestURL.Scheme)
+		span.Attributes().PutStr(attrURLTarget, requestURL.Path)
 
-		putIfNotExists(span.Attributes(), "http.response_content_length", random.IntBetween(100_000, 1_000_000))
+		putIfNotExists(span.Attributes(), attrHTTPResponseHeaderContentLength, []int{random.IntBetween(100_000, 1_000_000)})
 		if method == http.MethodPatch || method == http.MethodPost || method == http.MethodPut {
-			putIfNotExists(span.Attributes(), "http.request_content_length", random.IntBetween(10_000, 100_000))
+			putIfNotExists(span.Attributes(), attrHTTPRequestHeaderContentLength, []int{random.IntBetween(10_000, 100_000)})
 		}
 
 		if parent != nil && parent.Kind() == ptrace.SpanKindClient {
@@ -463,14 +458,14 @@ func (g *TemplatedGenerator) generateHTTPAttributes(tmpl *internalSpanTemplate, 
 				parent.Status().SetCode(ptrace.StatusCodeError)
 				parent.Status().SetMessage(http.StatusText(int(status)))
 			}
-			putIfNotExists(parent.Attributes(), "http.method", method)
-			putIfNotExists(parent.Attributes(), "http.request.header.accept", contentType)
-			putIfNotExists(parent.Attributes(), "http.status_code", status)
-			putIfNotExists(parent.Attributes(), "http.url", requestURL.String())
-			res, _ := span.Attributes().Get("http.response_content_length")
-			putIfNotExists(parent.Attributes(), "http.response_content_length", res.Int())
-			if req, found := span.Attributes().Get("http.request_content_length"); found {
-				putIfNotExists(span.Attributes(), "http.request_content_length", req.Int())
+			putIfNotExists(parent.Attributes(), attrHTTPMethod, method)
+			putIfNotExists(parent.Attributes(), attrHTTPRequestHeaderAccept, contentType)
+			putIfNotExists(parent.Attributes(), attrHTTPStatusCode, status)
+			putIfNotExists(parent.Attributes(), attrURL, requestURL.String())
+			res, _ := span.Attributes().Get(attrHTTPResponseHeaderContentLength)
+			putIfNotExists(span.Attributes(), attrHTTPResponseHeaderContentLength, res.AsRaw())
+			if req, found := span.Attributes().Get(attrHTTPRequestHeaderContentLength); found {
+				putIfNotExists(span.Attributes(), attrHTTPRequestHeaderContentLength, req.AsRaw())
 			}
 		}
 	}
@@ -809,4 +804,28 @@ func (g *TemplatedGenerator) initializeLinks(linkTemplates []Link, randomLinks, 
 	}
 
 	return internalLinks
+}
+
+func getHTTPStatusCode(attributes pcommon.Map) (int64, bool) {
+	st, found := attributes.Get(attrHTTPStatusCode)
+	if found {
+		return st.Int(), found
+	}
+	st, found = attributes.Get(attrHTTPStatusCodeOld)
+	if found {
+		return st.Int(), found
+	}
+	return 0, false
+}
+
+func getHTTPMethod(attributes pcommon.Map) (string, bool) {
+	m, found := attributes.Get(attrHTTPMethod)
+	if found {
+		return m.Str(), found
+	}
+	m, found = attributes.Get(attrHTTPMethodOld)
+	if found {
+		return m.Str(), found
+	}
+	return "", false
 }

--- a/pkg/tracegen/templated.go
+++ b/pkg/tracegen/templated.go
@@ -448,9 +448,9 @@ func (g *TemplatedGenerator) generateHTTPAttributes(tmpl *internalSpanTemplate, 
 		span.Attributes().PutStr(attrURLScheme, requestURL.Scheme)
 		span.Attributes().PutStr(attrURLTarget, requestURL.Path)
 
-		putIfNotExists(span.Attributes(), attrHTTPResponseHeaderContentLength, []int{random.IntBetween(100_000, 1_000_000)})
+		putIfNotExists(span.Attributes(), attrHTTPResponseHeaderContentLength, []any{random.IntBetween(100_000, 1_000_000)})
 		if method == http.MethodPatch || method == http.MethodPost || method == http.MethodPut {
-			putIfNotExists(span.Attributes(), attrHTTPRequestHeaderContentLength, []int{random.IntBetween(10_000, 100_000)})
+			putIfNotExists(span.Attributes(), attrHTTPRequestHeaderContentLength, []any{random.IntBetween(10_000, 100_000)})
 		}
 
 		if parent != nil && parent.Kind() == ptrace.SpanKindClient {

--- a/pkg/tracegen/templated_test.go
+++ b/pkg/tracegen/templated_test.go
@@ -23,7 +23,7 @@ func TestTemplatedGenerator_Traces(t *testing.T) {
 			{Service: "test-service", Name: ptr("perform-test"), RandomAttributes: &AttributeParams{Count: 2}},
 			{Service: "test-service"},
 			{Service: "test-service", Name: ptr("get_test_data")},
-			{Service: "test-data", Name: ptr("list_test_data"), Attributes: map[string]interface{}{"http.status_code": 400}},
+			{Service: "test-data", Name: ptr("list_test_data"), Attributes: map[string]interface{}{attrHTTPStatusCode: 400}},
 			{Service: "test-forced-semantic", AttributeSemantics: &attributeSemantics[0]},
 		},
 	}
@@ -45,10 +45,10 @@ func TestTemplatedGenerator_Traces(t *testing.T) {
 				if span.Kind() != ptrace.SpanKindInternal {
 					requireAttributeCountGreaterOrEqual(t, span.Attributes(), 3, "net.")
 					if *template.Defaults.AttributeSemantics == SemanticsHTTP {
-						requireAttributeCountGreaterOrEqual(t, span.Attributes(), 5, "http.")
+						requireAttributeCountGreaterOrEqual(t, span.Attributes(), 3, "http.")
 					}
 					if spanTemplate.AttributeSemantics != nil && *spanTemplate.AttributeSemantics == SemanticsHTTP {
-						requireAttributeCountGreaterOrEqual(t, span.Attributes(), 5, "http.")
+						requireAttributeCountGreaterOrEqual(t, span.Attributes(), 3, "http.")
 					}
 				}
 			}
@@ -83,7 +83,7 @@ func TestTemplatedGenerator_Resource(t *testing.T) {
 
 	for range testRounds {
 		for _, res := range iterResources(gen.Traces()) {
-			srv, found := res.Attributes().Get("service.name")
+			srv, found := res.Attributes().Get(attrServiceName)
 			require.True(t, found, "service.name not found")
 
 			switch srv.Str() {
@@ -116,7 +116,7 @@ func TestTemplatedGenerator_EventsLinks(t *testing.T) {
 			{Service: "test-service", Name: ptr("default_and_template"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}},
 			{Service: "test-service", Name: ptr("default_and_random"), RandomEvents: &EventParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
 			{Service: "test-service", Name: ptr("default_template_random"), Events: []Event{{Name: "event-name", RandomAttributes: &AttributeParams{Count: 2}}}, Links: []Link{{Attributes: map[string]interface{}{"link-attr-key": "link-attr-value"}}}, RandomEvents: &EventParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}, RandomLinks: &LinkParams{Count: 2, RandomAttributes: &AttributeParams{Count: 1}}},
-			{Service: "test-service", Name: ptr("default_generate_on_error"), Attributes: map[string]interface{}{"http.status_code": 400}},
+			{Service: "test-service", Name: ptr("default_generate_on_error"), Attributes: map[string]interface{}{attrHTTPStatusCode: 400}},
 		},
 	}
 

--- a/pkg/tracegen/tracegen.go
+++ b/pkg/tracegen/tracegen.go
@@ -4,6 +4,21 @@ import (
 	"go.opentelemetry.io/collector/pdata/ptrace"
 )
 
+const (
+	attrServiceName                     = "service.name"
+	attrHTTPStatusCode                  = "http.response.status_code"
+	attrHTTPStatusCodeOld               = "http.status_code"
+	attrHTTPMethod                      = "http.request.method"
+	attrHTTPMethodOld                   = "http.method"
+	attrHTTPRequestHeaderAccept         = "http.request.header.accept"
+	attrHTTPRequestHeaderContentLength  = "http.request.header.content-length"
+	attrHTTPResponseHeaderContentLength = "http.response.header.content-length"
+	attrHTTPResponseHeaderContentType   = "http.response.header.content-type"
+	attrURL                             = "url.full"
+	attrURLScheme                       = "url.schema"
+	attrURLTarget                       = "url.target"
+)
+
 // Generator creates traces to be used in k6 tests
 type Generator interface {
 	Traces() ptrace.Traces


### PR DESCRIPTION
Use attribute names that are more aligned with recent version of the OTEL semantic conventions