### PR TITLE
build: pin go toolchain to latest patch version for security

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-client-tracing
 
 go 1.25.4
 
+toolchain go1.25.10
+
 tool (
 	golang.org/x/tools/cmd/goimports
 	gotest.tools/gotestsum


### PR DESCRIPTION
Pin the Go toolchain in go.mod to the latest patch version of the minor it currently targets, picking up the latest security and bugfix releases.