### PR TITLE
chore: add Renovate config extending k6-engine-base preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json"
+  ]
+}


### PR DESCRIPTION
Adds a Renovate config extending the shared `github>grafana/grafana-renovate-config//presets/k6/k6-engine-base.json` preset, aligning this repo with the rest of the k6 extensions.