### PR TITLE
Fix docker-compose examples

### DIFF
--- a/examples/param/docker-compose.yml
+++ b/examples/param/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   k6-tracing:
     image: ghcr.io/grafana/xk6-client-tracing:latest
@@ -20,9 +18,5 @@ services:
       - ../shared/collector-config.yaml:/collector-config.yaml:ro
     ports:
       - "13133:13133"
-      - "14250:14250"
-      - "14268:14268"
-      - "55678-55679:55678-55679"
       - "4317:4317"
       - "4318:4318"
-      - "9411:9411"

--- a/examples/shared/collector-config.yaml
+++ b/examples/shared/collector-config.yaml
@@ -3,17 +3,14 @@ receivers:
     protocols:
       grpc:
       http:
-  jaeger:
-    protocols:
-      grpc:
 exporters:
-  logging:
-    loglevel: debug
+  debug:
+    verbosity: detailed
     sampling_initial: 5
     sampling_thereafter: 200
 service:
   pipelines:
     traces:
-      exporters: ["logging"]
+      exporters: ["debug"]
       processors: []
-      receivers: ["otlp", "jaeger"]
+      receivers: ["otlp"]

--- a/examples/shared/collector-config.yaml
+++ b/examples/shared/collector-config.yaml
@@ -2,7 +2,9 @@ receivers:
   otlp:
     protocols:
       grpc:
+        endpoint: 0.0.0.0:4317
       http:
+        endpoint: 0.0.0.0:4318
 exporters:
   debug:
     verbosity: detailed

--- a/examples/template/docker-compose.yml
+++ b/examples/template/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   k6-tracing:
     image: ghcr.io/grafana/xk6-client-tracing:latest
@@ -20,9 +18,5 @@ services:
       - ../shared/collector-config.yaml:/collector-config.yaml:ro
     ports:
       - "13133:13133"
-      - "14250:14250"
-      - "14268:14268"
-      - "55678-55679:55678-55679"
       - "4317:4317"
       - "4318:4318"
-      - "9411:9411"


### PR DESCRIPTION
The docker compose examples used an outdated, incompatible OTEL collector config. This PR fixes the config and the docker-compose examples.